### PR TITLE
Enable CircleCI testing in mewarpx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,81 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+
+version: 2.1
+
+orbs:
+  codecov: codecov/codecov@1.2.3
+
+jobs:
+
+  build_and_test_job:
+    docker:
+      # specify the version you desire here
+      # This is a CircleCI convenience image with CI & python packages
+      # pre-installed.
+      - image: cimg/python:3.9
+
+    working_directory: ~/WarpX
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v3-dependencies-{{ checksum "mewarpx/setup.py" }}-{{ checksum ".circleci/config.yml" }}
+
+      - run:
+          name: install dependencies
+          command: |
+            .github/workflows/dependencies/pyfull.sh
+
+            python3 -m venv venv
+            . venv/bin/activate
+
+            python3 -m pip install --upgrade pip setuptools wheel
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v3-dependencies-{{ checksum "mewarpx/setup.py" }}-{{ checksum ".circleci/config.yml" }}
+
+      - run:
+          name: build WarpX install mewarpx
+          command: |
+            echo 'activate venv; cd'
+            . venv/bin/activate
+
+            export WarpX_MPI=ON
+            export WarpX_OPENPMD=ON
+            export WarpX_PSATD=ON
+            export WarpX_QED_TABLE_GEN=ON
+            export CC=$(which clang)
+            export CXX=$(which clang++)
+            python3 -m pip install -v .
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            cd mewarpx
+            mkdir test-reports
+            pytest --runall --junitxml=test-reports/junit.xml --cov=mewarpx --cov-report=xml
+
+      - store_test_results:
+          path: mewarpx/test-reports
+
+      - store_artifacts:
+          path: mewarpx/test-reports
+          destination: test-reports
+
+      - codecov/upload
+
+# https://circleci.com/docs/2.0/workflows/
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build_and_test_job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
             echo 'activate venv; cd'
             . venv/bin/activate
 
+            # WarpX + PyWarpX compile & install
             export WarpX_MPI=ON
             export WarpX_OPENPMD=ON
             export WarpX_PSATD=ON
@@ -54,6 +55,10 @@ jobs:
             export CC=$(which clang)
             export CXX=$(which clang++)
             python3 -m pip install -v .
+
+            # Install development mode of mewarpx
+            cd mewarpx
+            pip install -e .[complete]
 
       # run tests!
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
             . venv/bin/activate
             cd mewarpx
             mkdir test-reports
-            pytest --runall --junitxml=test-reports/junit.xml --cov=mewarpx --cov-report=xml
+            pytest --junitxml=test-reports/junit.xml --cov=mewarpx --cov-report=xml
 
       - store_test_results:
           path: mewarpx/test-reports

--- a/mewarpx/.coveragerc
+++ b/mewarpx/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source=mewarpx

--- a/mewarpx/changelog.csv
+++ b/mewarpx/changelog.csv
@@ -1,0 +1,23 @@
+Version, Date,        List of changes
+0.1.0,   In progress, "
+
+**Physics changes**:
+
+- Initial release
+
+**Features**:
+
+- Initial release
+
+**API Changes**:
+
+- Initial release
+
+**Other changes**:
+
+- Initial release
+
+**Bugfixes**:
+
+- Initial release
+"

--- a/mewarpx/mewarpx/util.py
+++ b/mewarpx/mewarpx/util.py
@@ -1,7 +1,14 @@
 """
 Utility functions for mewarpx.
 """
+import inspect
+import os
+
 from pywarpx import geometry
+
+# http://stackoverflow.com/questions/50499/in-python-how-do-i-get-the-path-and-name-of-the-file-t
+mewarpx_dir = os.path.dirname(os.path.abspath(
+    inspect.getfile(inspect.currentframe())))
 
 
 def init_libwarpx(ndim, rz):

--- a/mewarpx/pytest.ini
+++ b/mewarpx/pytest.ini
@@ -1,0 +1,25 @@
+[pytest]
+# Trying new xunit2 format for junit test metadata
+junit_family=xunit2
+# Add command line options to force each test to run in a separate process.
+# Note that this requires pytest-xdist! But tests will break if this is not
+# used, because MEWarpX is not designed to reset gracefully between tests.
+# Finally, note that conftest.py can dynamically change command line arguments,
+# but this seems to break with pytest-xdist so cannot be used here.
+addopts = --boxed -n2
+
+# Warnings: In the past -Werror was used in addopts above. Recent changes to
+# pytest cause harmless import warnings to make pytest fail on import. In order
+# to filter these, we use filterwarnings instead. Hopefully this still works
+# well with pytest-xdist; I'm pretty sure it will.
+# The necessary warnings to filter will likely vary rapidly with the version
+# of other packages.
+# Note also that the 'message' field in these filters is a regular expression.
+# Among other things, that means that parentheses need to be escaped.
+
+# The numpy dtype/ufunc size changed come when scipy was compiled against a
+# different version of numpy than used here, but it's harmless and common.
+filterwarnings =
+    error
+    ignore:numpy.dtype size changed:RuntimeWarning
+    ignore:numpy.ufunc size changed:RuntimeWarning

--- a/mewarpx/setup.py
+++ b/mewarpx/setup.py
@@ -10,7 +10,7 @@ requires = [
 ]
 
 extras = {
-    # "tests": ["pytest", "pytest-cov", "pytest-xdist"],
+    "tests": ["pytest", "pytest-cov", "pytest-xdist"],
     # "docs": ["sphinx", "mock", "sphinx_rtd_theme"],
     # "aws": ["awscli", "boto3", "s3fs"]
 }

--- a/mewarpx/tests/test_package.py
+++ b/mewarpx/tests/test_package.py
@@ -1,6 +1,4 @@
 """Test basic package aspects"""
-from __future__ import print_function
-
 # Native python imports
 from builtins import next
 import csv

--- a/mewarpx/tests/test_package.py
+++ b/mewarpx/tests/test_package.py
@@ -1,0 +1,21 @@
+"""Test basic package aspects"""
+from __future__ import print_function
+
+# Native python imports
+from builtins import next
+import csv
+import os
+
+# 3rd-party library imports
+
+# Local imports
+import mewarpx
+from mewarpx import util
+
+
+def test_version():
+    with open(os.path.join(util.mewarpx_dir, '../changelog.csv'), 'r') as f:
+        reader = csv.reader(f)
+        next(reader)
+        row = next(reader)
+        assert row[0] == mewarpx.__version__


### PR DESCRIPTION
@kzhu-ME @MKieburtz @nruof whichever of use is most interested in continuous integration, plus @roelof-groenewald , can review, given our choice to do 2 reviews for internal PRs.

The guts of this are a CircleCI config file that builds and installs WarpX in a docker image, installs mewarpx, and then runs `pytest` inside mewarpx. You can go to circleci.com to view the actual test results, and we'll have code coverage at codecov.io though we'll need to figure out accounts for that.