### PR TITLE
[mini-PR] Fix duplicate code issue from simultaneous development

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolver_ME.cpp
+++ b/Source/FieldSolver/ElectrostaticSolver_ME.cpp
@@ -106,12 +106,13 @@ WarpX::computePhi (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho,
                    amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                    std::array<Real, 3> const beta,
                    Real const required_precision,
-                   int const max_iters) const
+                   int const max_iters,
+                   int const verbosity) const
 {
 #ifdef WARPX_DIM_RZ
-    computePhiRZ( rho, phi, beta, required_precision, max_iters );
+    computePhiRZ( rho, phi, beta, required_precision, max_iters, verbosity );
 #else
-    computePhiCartesian( rho, phi, beta, required_precision, max_iters );
+    computePhiCartesian( rho, phi, beta, required_precision, max_iters, verbosity );
 #endif
 
 }
@@ -134,7 +135,8 @@ WarpX::computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho
                    amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                    std::array<Real, 3> const beta,
                    Real const required_precision,
-                   int const max_iters) const
+                   int const max_iters,
+                   int const verbosity) const
 {
     // Create a new geometry with the z coordinate scaled by gamma
     amrex::Real const gamma = std::sqrt(1._rt/(1. - beta[2]*beta[2]));
@@ -251,7 +253,7 @@ WarpX::computePhiRZ (const amrex::Vector<std::unique_ptr<amrex::MultiFab> >& rho
     // Solve the Poisson equation
     linop.setDomainBC( lobc, hibc );
     MLMG mlmg(linop);
-    mlmg.setVerbose(2);
+    mlmg.setVerbose(verbosity);
     mlmg.setMaxIter(max_iters);
     mlmg.solve( GetVecOfPtrs(phi), GetVecOfConstPtrs(rho), required_precision, 0.0);
 }
@@ -275,7 +277,8 @@ WarpX::computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab>
                             amrex::Vector<std::unique_ptr<amrex::MultiFab> >& phi,
                             std::array<Real, 3> const beta,
                             Real const required_precision,
-                            int const max_iters) const
+                            int const max_iters,
+                            int const verbosity) const
 {
 
     // Define the boundary conditions
@@ -330,7 +333,7 @@ WarpX::computePhiCartesian (const amrex::Vector<std::unique_ptr<amrex::MultiFab>
     }
 
     MLMG mlmg(linop);
-    mlmg.setVerbose(0);
+    mlmg.setVerbose(verbosity);
     mlmg.setMaxIter(max_iters);
     mlmg.solve( GetVecOfPtrs(phi), GetVecOfConstPtrs(rho), required_precision, 0.0);
 }

--- a/Source/Python/WarpXWrappers.cpp
+++ b/Source/Python/WarpXWrappers.cpp
@@ -521,13 +521,4 @@ extern "C"
         auto & mypc = WarpX::GetInstance().GetPartContainer();
         mypc.Redistribute();
     }
-
-    int warpx_getMyProc() {
-        return amrex::ParallelDescriptor::MyProc();
-    }
-
-    int warpx_getNProcs() {
-        return amrex::ParallelDescriptor::NProcs();
-    }
-
 }


### PR DESCRIPTION
The wrapper for getting current processor rank and total processor count was duplicated in this PR. Also fixed outdated function templates in ElectrostaticSolver_ME.cpp.

This should be a really quick review.