### PR TITLE
Fix rtd theme

### DIFF
--- a/mewarpx/docs/mewarpx.diags_store.rst
+++ b/mewarpx/docs/mewarpx.diags_store.rst
@@ -4,6 +4,14 @@ mewarpx.diags\_store package
 Submodules
 ----------
 
+mewarpx.diags\_store.checkpoint\_diagnostic module
+--------------------------------------------------
+
+.. automodule:: mewarpx.diags_store.checkpoint_diagnostic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 mewarpx.diags\_store.diag\_base module
 --------------------------------------
 

--- a/mewarpx/docs/mewarpx.utils_store.rst
+++ b/mewarpx/docs/mewarpx.utils_store.rst
@@ -12,10 +12,26 @@ mewarpx.utils\_store.appendablearray module
    :undoc-members:
    :show-inheritance:
 
+mewarpx.utils\_store.init\_restart\_util module
+-----------------------------------------------
+
+.. automodule:: mewarpx.utils_store.init_restart_util
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 mewarpx.utils\_store.mwxconstants module
 ----------------------------------------
 
 .. automodule:: mewarpx.utils_store.mwxconstants
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mewarpx.utils\_store.mwxlogging module
+--------------------------------------
+
+.. automodule:: mewarpx.utils_store.mwxlogging
    :members:
    :undoc-members:
    :show-inheritance:
@@ -32,6 +48,22 @@ mewarpx.utils\_store.plotting module
 ------------------------------------
 
 .. automodule:: mewarpx.utils_store.plotting
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mewarpx.utils\_store.profileparser module
+-----------------------------------------
+
+.. automodule:: mewarpx.utils_store.profileparser
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mewarpx.utils\_store.pulsing module
+-----------------------------------
+
+.. automodule:: mewarpx.utils_store.pulsing
    :members:
    :undoc-members:
    :show-inheritance:

--- a/mewarpx/setup.py
+++ b/mewarpx/setup.py
@@ -15,7 +15,8 @@ requires = [
     "dill",
     # added on 10/25/21 due to an issue with rendering LaTex in pulse waveform
     # plot, this can be reverted once that issue is fixed
-    "pyparsing<3.0.0"
+    "pyparsing<3.0.0",
+    "sphinx-rtd-theme<1.0.0"
 ]
 
 extras = {


### PR DESCRIPTION
sphinx-rtd-theme package update to 1.0.0 broke styling for us, so we are reverting back to using 0.4.3