### PR TITLE
After diagnostic callback

### DIFF
--- a/Python/pywarpx/callbacks.py
+++ b/Python/pywarpx/callbacks.py
@@ -29,6 +29,7 @@ Functions can be called at the following times:
  - afterdeposition <installafterdeposition>: after particle deposition (for charge and/or current)
  - beforestep <installbeforestep>: before the time step
  - afterstep <installafterstep>: after the time step
+ - afterdiagnostics <installafterdiagnostics>: after diagnostic output
  - particlescraper <installparticlescraper>: just after the particle boundary conditions are applied
                                              but before lost particles are processed
  - particleloader <installparticleloader>: at the time that the standard particle loader is called
@@ -261,6 +262,7 @@ _particlescraper = CallbackFunctions('particlescraper')
 _particleloader = CallbackFunctions('particleloader')
 _beforestep = CallbackFunctions('beforestep')
 _afterstep = CallbackFunctions('afterstep')
+_afterdiagnostics = CallbackFunctions('afterdiagnostics')
 _afterrestart = CallbackFunctions('afterrestart',lcallonce=1)
 _particleinjection = CallbackFunctions('particleinjection')
 _appliedfields = CallbackFunctions('appliedfields')
@@ -279,6 +281,7 @@ def printcallbacktimers(tmin=1.,lminmax=False,ff=None):
               _particlescraper,
               _particleloader,
               _beforestep,_afterstep,
+              _afterdiagnostics,
               _afterrestart,
               _particleinjection,
               _appliedfields]:
@@ -470,6 +473,20 @@ def uninstallafterstep(f):
 def isinstalledafterstep(f):
     "Checks if the function is called after a step"
     return _afterstep.isinstalledfuncinlist(f)
+
+# ----------------------------------------------------------------------------
+def callfromafterdiagnostics(f):
+    installafterdiagnostics(f)
+    return f
+def installafterdiagnostics(f):
+    "Adds a function to the list of functions called after diagnostic output"
+    _afterdiagnostics.installfuncinlist(f)
+def uninstallafterdiagnostics(f):
+    "Removes the function from the list of functions called after diagnostic output"
+    _afterdiagnostics.uninstallfuncinlist(f)
+def isinstalledafterdiagnostics(f):
+    "Checks if the function is called after diagnostic output"
+    return _afterdiagnostics.isinstalledfuncinlist(f)
 
 # ----------------------------------------------------------------------------
 def callfromafterrestart(f):

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -335,6 +335,9 @@ WarpX::Evolve (int numsteps)
         }
         multi_diags->FilterComputePackFlush( step );
 
+        // execute afterdiagnostic callbacks
+        ExecutePythonCallback("afterdiagnostics");
+
         // inputs: unused parameters (e.g. typos) check after step 1 has finished
         if (!early_params_checked) {
             amrex::Print() << "\n"; // better: conditional \n based on return value

--- a/Source/Python/WarpX_py.H
+++ b/Source/Python/WarpX_py.H
@@ -21,8 +21,8 @@
  * functions will be called. Currently supported keys (callback points) are
  * afterinit, beforecollisions, aftercollisions, beforeEsolve, poissonsolver,
  * afterEsolve, beforedeposition, afterdeposition, particlescraper,
- * particleloader, beforestep, afterstep, afterrestart, particleinjection and
- * appliedfields.
+ * particleloader, beforestep, afterstep, afterdiagnostics, afterrestart,
+ * particleinjection and appliedfields.
 */
 extern std::map< std::string, WARPX_CALLBACK_PY_FUNC_0 > warpx_callback_py_map;
 


### PR DESCRIPTION
Actually installing an after checkpoint diagnostic as we've previously discussed is complicated since WarpX treats checkpoints as regular diagnostics. This gets us most of the benefit we would have from such a callback so I think this is a good compromise. Happy to hear counter arguments though.